### PR TITLE
http dc proximity voice chat channel ID info

### DIFF
--- a/minecraft-plugin/src/main/java/com/pvchat/proximityvoicechat/plugin/ProximityVoiceChat.java
+++ b/minecraft-plugin/src/main/java/com/pvchat/proximityvoicechat/plugin/ProximityVoiceChat.java
@@ -5,10 +5,14 @@ import com.pvchat.proximityvoicechat.plugin.config.ConfigManager;
 import com.pvchat.proximityvoicechat.plugin.config.linkmanagers.DiscordLink;
 import com.pvchat.proximityvoicechat.plugin.config.linkmanagers.DiscordSRVDiscordLink;
 import com.pvchat.proximityvoicechat.plugin.distancematrix.PlayerDistanceAndVolumeCalculations;
+import com.pvchat.proximityvoicechat.plugin.http.PVCHttpServer;
 import com.pvchat.proximityvoicechat.plugin.socket.PlayerVolumeServer;
 import github.scarsz.discordsrv.DiscordSRV;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.java.JavaPlugin;
+
+import java.io.IOException;
+import java.util.logging.Level;
 
 
 public final class ProximityVoiceChat extends JavaPlugin {
@@ -18,6 +22,7 @@ public final class ProximityVoiceChat extends JavaPlugin {
     private DiscordLink discordLink;
 
     private PlayerVolumeServer socketServer;
+    private PVCHttpServer httpServer;
 
     @Override
     public void onEnable() {
@@ -33,6 +38,13 @@ public final class ProximityVoiceChat extends JavaPlugin {
 
         Bukkit.getScheduler().scheduleAsyncDelayedTask(this, socketServer::run);
 
+        try {
+            httpServer = new PVCHttpServer(this, configManager.getHttpServerPort());
+            Bukkit.getScheduler().scheduleAsyncDelayedTask(this, httpServer::start);
+        }catch(IOException e){
+            getLogger().log(Level.WARNING, "Error starting http server. Might be port conflict.");
+            e.printStackTrace();
+        }
 
         playerDistanceAndVolumeCalculations = new PlayerDistanceAndVolumeCalculations(this, configManager.getMaxHearDistance(), configManager.getNoAttenuationDistance(), socketServer.sendPlayerVolumeMatrix);
 
@@ -53,6 +65,7 @@ public final class ProximityVoiceChat extends JavaPlugin {
     @Override
     public void onDisable() {
         socketServer.stopServer();
+        httpServer.stop(0);
     }
 
     public DiscordLink getDiscordLink() {
@@ -66,4 +79,6 @@ public final class ProximityVoiceChat extends JavaPlugin {
     public ConfigManager getConfigManager() {
         return configManager;
     }
+
+
 }

--- a/minecraft-plugin/src/main/java/com/pvchat/proximityvoicechat/plugin/config/ConfigManager.java
+++ b/minecraft-plugin/src/main/java/com/pvchat/proximityvoicechat/plugin/config/ConfigManager.java
@@ -14,6 +14,8 @@ public class ConfigManager {
     private int maxHearDistance;
     private int noAttenuationDistance;
     private int webSocketPort;
+    private int httpServerPort;
+    private String discordPVCChannelID;
 
     //Player IGN - discord name map
     private Map<UUID, DiscordUserID> playerLinks;
@@ -28,6 +30,8 @@ public class ConfigManager {
         maxHearDistance = config.getInt("maxHearDistance");
         noAttenuationDistance = config.getInt("noAttenuationDistance");
         webSocketPort = config.getInt("webSocketPort");
+        httpServerPort = config.getInt("httpServerPort");
+        discordPVCChannelID = config.getString("discordPVCChannelID");
         ConfigurationSection section = config.getConfigurationSection("links");
         playerLinks = new HashMap<>();
         if (section != null) {
@@ -35,7 +39,6 @@ public class ConfigManager {
             keys.forEach(s -> {
                 String value = section.getString(s);
                 if (value != null) playerLinks.put(UUID.fromString(s), DiscordUserID.parse(value));
-
             });
         }
     }
@@ -68,4 +71,19 @@ public class ConfigManager {
         return webSocketPort;
     }
 
+    public int getHttpServerPort() {
+        return httpServerPort;
+    }
+
+    public void setHttpServerPort(int httpServerPort) {
+        this.httpServerPort = httpServerPort;
+    }
+
+    public String getDiscordPVCChannelID() {
+        return discordPVCChannelID;
+    }
+
+    public void setDiscordPVCChannelID(String discordPVCChannelID) {
+        this.discordPVCChannelID = discordPVCChannelID;
+    }
 }

--- a/minecraft-plugin/src/main/java/com/pvchat/proximityvoicechat/plugin/http/GetChannelHandler.java
+++ b/minecraft-plugin/src/main/java/com/pvchat/proximityvoicechat/plugin/http/GetChannelHandler.java
@@ -1,0 +1,45 @@
+package com.pvchat.proximityvoicechat.plugin.http;
+
+import com.pvchat.proximityvoicechat.plugin.ProximityVoiceChat;
+import com.pvchat.proximityvoicechat.plugin.config.ConfigManager;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+
+public class GetChannelHandler implements HttpHandler {
+    private final ProximityVoiceChat plugin;
+
+    public GetChannelHandler(ProximityVoiceChat plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public void handle(HttpExchange exchange) throws IOException {
+        ConfigManager configManager = plugin.getConfigManager();
+        String discordPVCChannelID = configManager.getDiscordPVCChannelID();
+
+        exchange.getResponseHeaders().add("Content-type", "text/plain; charset=UTF-8");
+
+        byte[] response;
+        String requestMethod = exchange.getRequestMethod();
+
+        if (!requestMethod.equals("GET")) {
+            response = ("Not supported request method: " + requestMethod).getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(405, response.length);
+        }else if (discordPVCChannelID != null && discordPVCChannelID.strip().length() > 0) {
+            response = discordPVCChannelID.strip().getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(200, response.length);
+        } else {
+            response = "Discord proximity voice chat channel ID isn't set in minecraft plugin config (config.yml, attribute \"discordPVCChannelID\" is not set)".getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(503, response.length);
+        }
+
+        OutputStream outputStream = exchange.getResponseBody();
+        outputStream.write(response);
+        exchange.close();
+    }
+}

--- a/minecraft-plugin/src/main/java/com/pvchat/proximityvoicechat/plugin/http/PVCHttpServer.java
+++ b/minecraft-plugin/src/main/java/com/pvchat/proximityvoicechat/plugin/http/PVCHttpServer.java
@@ -1,0 +1,25 @@
+package com.pvchat.proximityvoicechat.plugin.http;
+
+import com.pvchat.proximityvoicechat.plugin.ProximityVoiceChat;
+import com.sun.net.httpserver.HttpServer;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+
+public class PVCHttpServer {
+
+    private final HttpServer server;
+
+    public PVCHttpServer(ProximityVoiceChat plugin, int port) throws IOException {
+        server = HttpServer.create(new InetSocketAddress(port), 0);
+        server.createContext("/channel", new GetChannelHandler(plugin)); // returns discord proximity voice chat channel id
+    }
+
+    public void start() {
+        server.start();
+    }
+
+    public void stop(int delay) {
+        server.stop(delay);
+    }
+}

--- a/minecraft-plugin/src/main/resources/config.yml
+++ b/minecraft-plugin/src/main/resources/config.yml
@@ -1,5 +1,7 @@
 maxHearDistance: 100
 noAttenuationDistance: 10
 webSocketPort: 8080
+httpServerPort: 8090
+discordPVCChannelID: 10000000000
 links:
   00000000-0000-0000-0000-000000000000: 0


### PR DESCRIPTION
Added http endpoint with
Http server port and discord PVC channel id can be changed in config.yml with options "httpServerPort" and "discordPVCChannelID", respectively.

To get info:
HTTP GET  <domain>:<http_server_port>/channel

When "discordPVCChannelID" is not set, http server responds with http response code 503 (Service Unavailable)
Otherwise the response code is 200 (OK), and discord pvc channel id is being send via Content-Type: text/plain.
Also it responds with 405 (Method not allowed) when we call a request method other than GET (e.g. POST).